### PR TITLE
featureCount function returns not number of layers but number of features.

### DIFF
--- a/materials/QGIS/QGIS.md
+++ b/materials/QGIS/QGIS.md
@@ -387,7 +387,7 @@ QGISでは、独自のPython関数が用意されており、それを読み込�
 #アクティブレイヤ（レイヤウインドウで選択した）をtokyoに代入する
 tokyo = iface.activeLayer()
 
-レイヤの個数を取得する（tokyo）
+地物の個数を取得する（tokyo）
 tokyo.featureCount()
 
 ```


### PR DESCRIPTION
featureCount関数の返り値の説明が「レイヤの個数」になっていたので「地物の個数」に修正しました。