### PR TITLE
｢リモートセンシングとその解析｣におけるLandBrowserへのリンクURIを変更

### DIFF
--- a/materials/06/06.md
+++ b/materials/06/06.md
@@ -224,7 +224,7 @@ QGISで画像を読み込み、[QGISビギナーズマニュアル]を参考に�
 
 [▲メニューへもどる]:./06.md#Menu
 [MultiSpecの公式サイト]:https://engineering.purdue.edu/~biehl/MultiSpec/
-[LandBrowser]:http://landbrowser.geogrid.org/landbrowser/
+[LandBrowser]:https://landbrowser.airc.aist.go.jp/landbrowser/index.html
 [利用規約]:../../policy.md
 [その他のライセンスについて]:../license.md
 [よくある質問とエラー]:../questions/questions.md


### PR DESCRIPTION
｢リモートセンシングとその解析｣のページにあるLandBrowserへのリンク先がアクセスできなかったため､新しいURIを調べて置換えました｡

現在は人工知能研究センターの｢[LandBrowserについて](https://www.airc.aist.go.jp/gsrt/lb-intro.html)｣ページからLandBrowserへのリンクが張られており､LandBrowserは`https://landbrowser.airc.aist.go.jp/landbrowser/index.html`のURIで機能しています｡